### PR TITLE
Add example test with ViewCreator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ debugCompile 'com.novoda:espresso-support-extras:<latest-version>'
 androidTestCompile 'com.novoda:espresso-support:<latest-version>'
 ```
 
+See `demo/androidTest` for examples.
+
 ## Testing views in isolation
 
 Use the `ViewTestRule`, passing in a layout resource. It'll inflate the resource into the `ViewActivity` with `MATCH_PARENT` for both dimensions. You can use `rule.getView()` to obtain an instance of the View and it'll be typed to the class you specified.

--- a/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
@@ -31,7 +31,15 @@ public class ProgrammaticallyCreatedViewTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Rule
-    public ViewTestRule<TextView> viewTestRule = new ViewTestRule<>(new ViewCreator<TextView>() {
+    public ViewTestRule<TextView> viewTestRule = new ViewTestRule<>(new TextViewCreator());
+
+    @Test
+    public void createdViewIsDisplayed() {
+        onView(withText(TEXT)).check(matches(isDisplayed()));
+    }
+
+    private static class TextViewCreator implements ViewCreator<TextView> {
+
         @Override
         public TextView createView(Context context, ViewGroup parentView) {
             TextView textView = new TextView(context);
@@ -40,10 +48,5 @@ public class ProgrammaticallyCreatedViewTest {
             textView.setText(TEXT);
             return textView;
         }
-    });
-
-    @Test
-    public void createdViewIsDisplayed() {
-        onView(withText(TEXT)).check(matches(isDisplayed()));
     }
 }

--- a/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
@@ -12,8 +12,6 @@ import com.novoda.espresso.ViewTestRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -26,9 +24,6 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 public class ProgrammaticallyCreatedViewTest {
 
     private static final String TEXT = "Hello world!";
-
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Rule
     public ViewTestRule<TextView> viewTestRule = new ViewTestRule<>(new TextViewCreator());

--- a/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
@@ -1,0 +1,49 @@
+package com.novoda.movies;
+
+import android.content.Context;
+import android.support.test.filters.LargeTest;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.novoda.espresso.ViewCreator;
+import com.novoda.espresso.ViewTestRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ProgrammaticallyCreatedViewTest {
+
+    private static final String TEXT = "Hello world!";
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public ViewTestRule<TextView> viewTestRule = new ViewTestRule<>(new ViewCreator<TextView>() {
+        @Override
+        public TextView createView(Context context, ViewGroup parentView) {
+            TextView textView = new TextView(context);
+            ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(WRAP_CONTENT, WRAP_CONTENT);
+            textView.setLayoutParams(layoutParams);
+            textView.setText(TEXT);
+            return textView;
+        }
+    });
+
+    @Test
+    public void createdViewIsDisplayed() {
+        onView(withText(TEXT)).check(matches(isDisplayed()));
+    }
+}


### PR DESCRIPTION
This pr:
adds a simple example to acknowledge that we support testing views created programmatically.