### PR TITLE
14/Add polling and waiting instead of naive wait for TalkBack toggling

### DIFF
--- a/core/src/main/java/com/novoda/espresso/TalkBackTestRule.java
+++ b/core/src/main/java/com/novoda/espresso/TalkBackTestRule.java
@@ -9,8 +9,6 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import java.util.List;
-
 import static android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_SPOKEN;
 
 public class TalkBackTestRule implements TestRule {
@@ -59,7 +57,7 @@ public class TalkBackTestRule implements TestRule {
             return new Condition() {
                 @Override
                 public boolean holds() {
-                    return !talkBackIsDisabled().holds();
+                    return spokenFeedbackServiceRunning();
                 }
             };
         }
@@ -68,9 +66,13 @@ public class TalkBackTestRule implements TestRule {
             return new Condition() {
                 @Override
                 public boolean holds() {
-                    return a11yManager.getEnabledAccessibilityServiceList(FEEDBACK_SPOKEN).isEmpty();
+                    return !spokenFeedbackServiceRunning();
                 }
             };
+        }
+
+        private boolean spokenFeedbackServiceRunning() {
+            return !a11yManager.getEnabledAccessibilityServiceList(FEEDBACK_SPOKEN).isEmpty();
         }
 
         private AssertionError talkBackToggleTimeOutError() {
@@ -78,6 +80,7 @@ public class TalkBackTestRule implements TestRule {
         }
 
         private interface Condition {
+
             boolean holds();
         }
     }

--- a/core/src/main/java/com/novoda/espresso/TalkBackTestRule.java
+++ b/core/src/main/java/com/novoda/espresso/TalkBackTestRule.java
@@ -1,10 +1,15 @@
 package com.novoda.espresso;
 
+import android.content.Context;
 import android.os.SystemClock;
+import android.support.test.InstrumentationRegistry;
+import android.view.accessibility.AccessibilityManager;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import static android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_SPOKEN;
 
 public class TalkBackTestRule implements TestRule {
 
@@ -15,10 +20,11 @@ public class TalkBackTestRule implements TestRule {
 
     private static class TalkBackStatement extends Statement {
 
-        private static final int DEFAULT_DELAY_MILLIS = 1500;
+        private static final int SLEEP_DELAY_MILLIS = 10;
 
-        private final TalkBackStateSettingRequester talkBackStateSettingRequester = new TalkBackStateSettingRequester(0);
         private final Statement baseStatement;
+        private final TalkBackStateSettingRequester talkBackStateSettingRequester = new TalkBackStateSettingRequester(0);
+        private final AccessibilityManager a11yManager = (AccessibilityManager) InstrumentationRegistry.getInstrumentation().getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
 
         TalkBackStatement(Statement baseStatement) {
             this.baseStatement = baseStatement;
@@ -27,16 +33,32 @@ public class TalkBackTestRule implements TestRule {
         @Override
         public void evaluate() throws Throwable {
             talkBackStateSettingRequester.requestEnableTalkBack();
-            sleepToAllowTalkBackServiceToChangeState();
+            sleepUntilTalkBackIsEnabled();
 
             baseStatement.evaluate();
 
             talkBackStateSettingRequester.requestDisableTalkBack();
-            sleepToAllowTalkBackServiceToChangeState();
+            sleepUntilTalkBackIsDisabled();
         }
 
-        private void sleepToAllowTalkBackServiceToChangeState() {
-            SystemClock.sleep(DEFAULT_DELAY_MILLIS);
+        private void sleepUntilTalkBackIsEnabled() {
+            while (talkBackDisabled()) {
+                SystemClock.sleep(SLEEP_DELAY_MILLIS);
+            }
+        }
+
+        private void sleepUntilTalkBackIsDisabled() {
+            while (talkBackEnabled()) {
+                SystemClock.sleep(SLEEP_DELAY_MILLIS);
+            }
+        }
+
+        private boolean talkBackEnabled() {
+            return !talkBackDisabled();
+        }
+
+        private boolean talkBackDisabled() {
+            return a11yManager.getEnabledAccessibilityServiceList(FEEDBACK_SPOKEN).isEmpty();
         }
     }
 }


### PR DESCRIPTION
Fixes #14 

We added the 1500ms wait because _occasionally_ the tests would fail because they were switching Talkback on/off too fast, and it hadn't completed when the test started.

If you have a large suite of tests, this isn't great, because it adds 3s per test.

Swapped that with a while loop and querying to see if TalkBack is in the desired state. Ran the suite 10 times and it didn't fail.