### PR TITLE
switch-access-feature/Add switch tests for RateableMovieItemView

### DIFF
--- a/demo/src/androidTest/java/com/novoda/movies/rateable/RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/RateableMovieViewHolderTest.java
@@ -2,7 +2,6 @@ package com.novoda.movies.rateable;
 
 import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
-import android.support.test.espresso.action.CoordinatesProvider;
 import android.support.test.espresso.action.GeneralClickAction;
 import android.support.test.espresso.action.Press;
 import android.support.test.espresso.action.Tap;
@@ -87,7 +86,7 @@ public class RateableMovieViewHolderTest {
         verify(userActions).onRate(4.5f);
     }
 
-    private static ViewAction setRating(final float rating) {
+    private static ViewAction setRating(float rating) {
         if (rating % 0.5 != 0) {
             throw new IllegalArgumentException("Rating must be multiple of 0.5f");
         }
@@ -107,16 +106,13 @@ public class RateableMovieViewHolderTest {
             public void perform(UiController uiController, View view) {
                 GeneralClickAction viewAction = new GeneralClickAction(
                         Tap.SINGLE,
-                        new CoordinatesProvider() {
-                            @Override
-                            public float[] calculateCoordinates(View view) {
-                                int numStars = ((RatingBar) view).getNumStars();
-                                float widthPerStar = 1f * view.getWidth() / numStars;
-                                float percent = rating / numStars;
-                                float x = view.getLeft() + view.getWidth() * percent;
-                                float y = view.getTop() + (view.getBottom() - view.getTop()) * 0.5f;
-                                return new float[]{x - widthPerStar * 0.5f, y};
-                            }
+                        viewToTap -> {
+                            int numStars = ((RatingBar) viewToTap).getNumStars();
+                            float widthPerStar = 1f * viewToTap.getWidth() / numStars;
+                            float percent = rating / numStars;
+                            float x = viewToTap.getLeft() + viewToTap.getWidth() * percent;
+                            float y = viewToTap.getTop() + (viewToTap.getBottom() - viewToTap.getTop()) * 0.5f;
+                            return new float[]{x - widthPerStar * 0.5f, y};
                         },
                         Press.FINGER,
                         InputDevice.SOURCE_UNKNOWN,

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/RateableMovieViewHolderTest.java
@@ -2,13 +2,8 @@ package com.novoda.movies.rateable;
 
 import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
-import android.support.test.espresso.action.GeneralClickAction;
-import android.support.test.espresso.action.Press;
-import android.support.test.espresso.action.Tap;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
-import android.view.InputDevice;
-import android.view.MotionEvent;
 import android.view.View;
 import android.widget.RatingBar;
 
@@ -104,21 +99,7 @@ public class RateableMovieViewHolderTest {
 
             @Override
             public void perform(UiController uiController, View view) {
-                GeneralClickAction viewAction = new GeneralClickAction(
-                        Tap.SINGLE,
-                        viewToTap -> {
-                            int numStars = ((RatingBar) viewToTap).getNumStars();
-                            float widthPerStar = 1f * viewToTap.getWidth() / numStars;
-                            float percent = rating / numStars;
-                            float x = viewToTap.getLeft() + viewToTap.getWidth() * percent;
-                            float y = viewToTap.getTop() + (viewToTap.getBottom() - viewToTap.getTop()) * 0.5f;
-                            return new float[]{x - widthPerStar * 0.5f, y};
-                        },
-                        Press.FINGER,
-                        InputDevice.SOURCE_UNKNOWN,
-                        MotionEvent.BUTTON_PRIMARY
-                );
-                viewAction.perform(uiController, view);
+                ((RatingBar) view).setRating(rating);
             }
         };
     }

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/SwitchAccess_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/SwitchAccess_RateableMovieViewHolderTest.java
@@ -2,6 +2,7 @@ package com.novoda.movies.rateable;
 
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
 
 import com.novoda.espresso.AccessibilityRules;
 import com.novoda.espresso.ViewTestRule;
@@ -28,7 +29,7 @@ import static org.mockito.Mockito.verify;
 @LargeTest
 public class SwitchAccess_RateableMovieViewHolderTest {
 
-    private ViewTestRule viewTestRule = new ViewTestRule(R.layout.item_view_rateable_movie);
+    private ViewTestRule<View> viewTestRule = new ViewTestRule<>(R.layout.item_view_rateable_movie);
 
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule(AccessibilityRules.createSwitchAccessTestRule()).around(viewTestRule);
@@ -45,7 +46,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     public void bindsTitle() {
         RateableMovieViewModel viewModel = viewModel().title("Arrival").rating(5).liked(true).build();
 
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_text_title)).check(matches(withText("Arrival")));
     }
@@ -53,7 +54,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     @Test
     public void clickingOnItemViewOpensMenu() {
         RateableMovieViewModel viewModel = viewModel().liked(false).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(underTest()).perform(click());
 
@@ -63,7 +64,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     @Test
     public void clickingOnItemViewOpensMenuWithUndoLike() {
         RateableMovieViewModel viewModel = viewModel().liked(true).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(underTest()).perform(click());
 
@@ -73,7 +74,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     @Test
     public void clickingOnLikeOpensMenu() {
         RateableMovieViewModel viewModel = viewModel().liked(false).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_image_like)).perform(click());
 
@@ -83,7 +84,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     @Test
     public void clickingOnRateOpensMenu() {
         RateableMovieViewModel viewModel = viewModel().liked(false).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_rating)).perform(click());
 
@@ -93,7 +94,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     @Test
     public void clickingOnRateActionOpensRateMenu() {
         RateableMovieViewModel viewModel = viewModel().build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
         onView(underTest()).perform(click());
 
         onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
@@ -104,7 +105,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
     @Test
     public void bindsRateAction() {
         RateableMovieViewModel viewModel = viewModel(userActions).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
         onView(underTest()).perform(click());
         onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
 

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/SwitchAccess_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/SwitchAccess_RateableMovieViewHolderTest.java
@@ -1,0 +1,152 @@
+package com.novoda.movies.rateable;
+
+import android.support.test.filters.LargeTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.novoda.espresso.AccessibilityRules;
+import com.novoda.espresso.ViewTestRule;
+import com.novoda.movies.R;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.novoda.espresso.ViewTestRule.underTest;
+import static com.novoda.movies.rateable.RateableMovieViewModelFixtures.viewModel;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class SwitchAccess_RateableMovieViewHolderTest {
+
+    private ViewTestRule viewTestRule = new ViewTestRule(R.layout.item_view_rateable_movie);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(AccessibilityRules.createSwitchAccessTestRule()).around(viewTestRule);
+
+    private RateableMovieViewHolder rateableMovieViewHolder;
+    private RateableMovieViewModel.UserActions userActions = mock(RateableMovieViewModel.UserActions.class);
+
+    @Before
+    public void setUp() {
+        rateableMovieViewHolder = new RateableMovieViewHolder(viewTestRule.getView());
+    }
+
+    @Test
+    public void bindsTitle() {
+        RateableMovieViewModel viewModel = viewModel().title("Arrival").rating(5).liked(true).build();
+
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(withId(R.id.item_rateable_text_title)).check(matches(withText("Arrival")));
+    }
+
+    @Test
+    public void clickingOnItemViewOpensMenu() {
+        RateableMovieViewModel viewModel = viewModel().build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(underTest()).perform(click());
+
+        checkSeeMoreOptionsMenuDisplayed();
+    }
+
+    @Test
+    public void clickingOnItemViewOpensMenuWithUndoLike() {
+        RateableMovieViewModel viewModel = viewModel().liked(true).build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(underTest()).perform(click());
+
+        checkSeeMoreOptionsMenuWithUndoLikeDisplayed();
+    }
+
+    @Test
+    public void clickingOnLikeOpensMenu() {
+        RateableMovieViewModel viewModel = viewModel().build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(withId(R.id.item_rateable_image_like)).perform(click());
+
+        checkSeeMoreOptionsMenuDisplayed();
+    }
+
+    @Test
+    public void clickingOnRateOpensMenu() {
+        RateableMovieViewModel viewModel = viewModel().build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(withId(R.id.item_rateable_rating)).perform(click());
+
+        checkSeeMoreOptionsMenuDisplayed();
+    }
+
+    @Test
+    public void clickingOnRateActionOpensRateMenu() {
+        RateableMovieViewModel viewModel = viewModel().build();
+        rateableMovieViewHolder.bind(viewModel);
+        onView(underTest()).perform(click());
+
+        onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
+
+        checkRateMenuDisplayed();
+    }
+
+    @Test
+    public void bindsRateAction() {
+        RateableMovieViewModel viewModel = viewModel(userActions).build();
+        rateableMovieViewHolder.bind(viewModel);
+        onView(underTest()).perform(click());
+        onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
+
+        onView(withText(R.string.action_rateable_movie_rate_one_half_star)).perform(click());
+
+        verify(userActions).onRate(1.5f);
+    }
+
+    private void checkRateMenuDisplayed() {
+        checkViewsWithTextDisplayed(
+                R.string.action_rateable_movie_rate_half_star,
+                R.string.action_rateable_movie_rate_one_star,
+                R.string.action_rateable_movie_rate_one_half_star,
+                R.string.action_rateable_movie_rate_two_star,
+                R.string.action_rateable_movie_rate_two_half_star,
+                R.string.action_rateable_movie_rate_three_star,
+                R.string.action_rateable_movie_rate_three_half_star,
+                R.string.action_rateable_movie_rate_four_star,
+                R.string.action_rateable_movie_rate_four_half_star,
+                R.string.action_rateable_movie_rate_five_star
+        );
+    }
+
+    private void checkSeeMoreOptionsMenuDisplayed() {
+        checkViewsWithTextDisplayed(
+                R.string.action_rateable_movie_click_select,
+                R.string.action_rateable_movie_click_like,
+                R.string.action_rateable_movie_click_rate
+        );
+    }
+
+    private void checkSeeMoreOptionsMenuWithUndoLikeDisplayed() {
+        checkViewsWithTextDisplayed(
+                R.string.action_rateable_movie_click_select,
+                R.string.action_rateable_movie_click_remove_like,
+                R.string.action_rateable_movie_click_rate
+        );
+    }
+
+    private void checkViewsWithTextDisplayed(int... ids) {
+        for (int id : ids) {
+            onView(withText(id)).check(matches(isDisplayed()));
+        }
+    }
+}

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/SwitchAccess_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/SwitchAccess_RateableMovieViewHolderTest.java
@@ -52,7 +52,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
 
     @Test
     public void clickingOnItemViewOpensMenu() {
-        RateableMovieViewModel viewModel = viewModel().build();
+        RateableMovieViewModel viewModel = viewModel().liked(false).build();
         rateableMovieViewHolder.bind(viewModel);
 
         onView(underTest()).perform(click());
@@ -72,7 +72,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
 
     @Test
     public void clickingOnLikeOpensMenu() {
-        RateableMovieViewModel viewModel = viewModel().build();
+        RateableMovieViewModel viewModel = viewModel().liked(false).build();
         rateableMovieViewHolder.bind(viewModel);
 
         onView(withId(R.id.item_rateable_image_like)).perform(click());
@@ -82,7 +82,7 @@ public class SwitchAccess_RateableMovieViewHolderTest {
 
     @Test
     public void clickingOnRateOpensMenu() {
-        RateableMovieViewModel viewModel = viewModel().build();
+        RateableMovieViewModel viewModel = viewModel().liked(false).build();
         rateableMovieViewHolder.bind(viewModel);
 
         onView(withId(R.id.item_rateable_rating)).perform(click());

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/TalkBack_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/TalkBack_RateableMovieViewHolderTest.java
@@ -1,0 +1,152 @@
+package com.novoda.movies.rateable;
+
+import android.support.test.filters.LargeTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.novoda.espresso.AccessibilityRules;
+import com.novoda.espresso.ViewTestRule;
+import com.novoda.movies.R;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.novoda.espresso.ViewTestRule.underTest;
+import static com.novoda.movies.rateable.RateableMovieViewModelFixtures.viewModel;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class TalkBack_RateableMovieViewHolderTest {
+
+    private ViewTestRule viewTestRule = new ViewTestRule(R.layout.item_view_rateable_movie);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(AccessibilityRules.createTalkBackTestRule()).around(viewTestRule);
+
+    private RateableMovieViewHolder rateableMovieViewHolder;
+    private RateableMovieViewModel.UserActions userActions = mock(RateableMovieViewModel.UserActions.class);
+
+    @Before
+    public void setUp() {
+        rateableMovieViewHolder = new RateableMovieViewHolder(viewTestRule.getView());
+    }
+
+    @Test
+    public void bindsTitle() {
+        RateableMovieViewModel viewModel = viewModel().title("Arrival").rating(5).liked(true).build();
+
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(withId(R.id.item_rateable_text_title)).check(matches(withText("Arrival")));
+    }
+
+    @Test
+    public void clickingOnItemViewOpensMenu() {
+        RateableMovieViewModel viewModel = viewModel().liked(false).build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(underTest()).perform(click());
+
+        checkSeeMoreOptionsMenuDisplayed();
+    }
+
+    @Test
+    public void clickingOnItemViewOpensMenuWithUndoLike() {
+        RateableMovieViewModel viewModel = viewModel().liked(true).build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(underTest()).perform(click());
+
+        checkSeeMoreOptionsMenuWithUndoLikeDisplayed();
+    }
+
+    @Test
+    public void clickingOnLikeOpensMenu() {
+        RateableMovieViewModel viewModel = viewModel().liked(false).build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(withId(R.id.item_rateable_image_like)).perform(click());
+
+        checkSeeMoreOptionsMenuDisplayed();
+    }
+
+    @Test
+    public void clickingOnRateOpensMenu() {
+        RateableMovieViewModel viewModel = viewModel().liked(false).build();
+        rateableMovieViewHolder.bind(viewModel);
+
+        onView(withId(R.id.item_rateable_rating)).perform(click());
+
+        checkSeeMoreOptionsMenuDisplayed();
+    }
+
+    @Test
+    public void clickingOnRateActionOpensRateMenu() {
+        RateableMovieViewModel viewModel = viewModel().build();
+        rateableMovieViewHolder.bind(viewModel);
+        onView(underTest()).perform(click());
+
+        onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
+
+        checkRateMenuDisplayed();
+    }
+
+    @Test
+    public void bindsRateAction() {
+        RateableMovieViewModel viewModel = viewModel(userActions).build();
+        rateableMovieViewHolder.bind(viewModel);
+        onView(underTest()).perform(click());
+        onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
+
+        onView(withText(R.string.action_rateable_movie_rate_one_half_star)).perform(click());
+
+        verify(userActions).onRate(1.5f);
+    }
+
+    private void checkRateMenuDisplayed() {
+        checkViewsWithTextDisplayed(
+                R.string.action_rateable_movie_rate_half_star,
+                R.string.action_rateable_movie_rate_one_star,
+                R.string.action_rateable_movie_rate_one_half_star,
+                R.string.action_rateable_movie_rate_two_star,
+                R.string.action_rateable_movie_rate_two_half_star,
+                R.string.action_rateable_movie_rate_three_star,
+                R.string.action_rateable_movie_rate_three_half_star,
+                R.string.action_rateable_movie_rate_four_star,
+                R.string.action_rateable_movie_rate_four_half_star,
+                R.string.action_rateable_movie_rate_five_star
+        );
+    }
+
+    private void checkSeeMoreOptionsMenuDisplayed() {
+        checkViewsWithTextDisplayed(
+                R.string.action_rateable_movie_click_select,
+                R.string.action_rateable_movie_click_like,
+                R.string.action_rateable_movie_click_rate
+        );
+    }
+
+    private void checkSeeMoreOptionsMenuWithUndoLikeDisplayed() {
+        checkViewsWithTextDisplayed(
+                R.string.action_rateable_movie_click_select,
+                R.string.action_rateable_movie_click_remove_like,
+                R.string.action_rateable_movie_click_rate
+        );
+    }
+
+    private void checkViewsWithTextDisplayed(int... ids) {
+        for (int id : ids) {
+            onView(withText(id)).check(matches(isDisplayed()));
+        }
+    }
+}

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/TalkBack_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/TalkBack_RateableMovieViewHolderTest.java
@@ -2,6 +2,7 @@ package com.novoda.movies.rateable;
 
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
 
 import com.novoda.espresso.AccessibilityRules;
 import com.novoda.espresso.ViewTestRule;
@@ -28,7 +29,7 @@ import static org.mockito.Mockito.verify;
 @LargeTest
 public class TalkBack_RateableMovieViewHolderTest {
 
-    private ViewTestRule viewTestRule = new ViewTestRule(R.layout.item_view_rateable_movie);
+    private ViewTestRule<View> viewTestRule = new ViewTestRule<>(R.layout.item_view_rateable_movie);
 
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule(AccessibilityRules.createTalkBackTestRule()).around(viewTestRule);
@@ -45,7 +46,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     public void bindsTitle() {
         RateableMovieViewModel viewModel = viewModel().title("Arrival").rating(5).liked(true).build();
 
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_text_title)).check(matches(withText("Arrival")));
     }
@@ -53,7 +54,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     @Test
     public void clickingOnItemViewOpensMenu() {
         RateableMovieViewModel viewModel = viewModel().liked(false).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(underTest()).perform(click());
 
@@ -63,7 +64,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     @Test
     public void clickingOnItemViewOpensMenuWithUndoLike() {
         RateableMovieViewModel viewModel = viewModel().liked(true).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(underTest()).perform(click());
 
@@ -73,7 +74,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     @Test
     public void clickingOnLikeOpensMenu() {
         RateableMovieViewModel viewModel = viewModel().liked(false).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_image_like)).perform(click());
 
@@ -83,7 +84,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     @Test
     public void clickingOnRateOpensMenu() {
         RateableMovieViewModel viewModel = viewModel().liked(false).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_rating)).perform(click());
 
@@ -93,7 +94,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     @Test
     public void clickingOnRateActionOpensRateMenu() {
         RateableMovieViewModel viewModel = viewModel().build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
         onView(underTest()).perform(click());
 
         onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
@@ -104,7 +105,7 @@ public class TalkBack_RateableMovieViewHolderTest {
     @Test
     public void bindsRateAction() {
         RateableMovieViewModel viewModel = viewModel(userActions).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
         onView(underTest()).perform(click());
         onView(withText(R.string.action_rateable_movie_click_rate)).perform(click());
 

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/TouchMode_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/TouchMode_RateableMovieViewHolderTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 public class TouchMode_RateableMovieViewHolderTest {
 
     @Rule
-    public ViewTestRule viewTestRule = new ViewTestRule(R.layout.item_view_rateable_movie);
+    public ViewTestRule<View> viewTestRule = new ViewTestRule<>(R.layout.item_view_rateable_movie);
 
     private RateableMovieViewHolder rateableMovieViewHolder;
     private RateableMovieViewModel.UserActions userActions = mock(RateableMovieViewModel.UserActions.class);
@@ -46,7 +46,7 @@ public class TouchMode_RateableMovieViewHolderTest {
     public void bindsTitle() {
         RateableMovieViewModel viewModel = viewModel().title("Arrival").rating(5).liked(true).build();
 
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_text_title)).check(matches(withText("Arrival")));
     }
@@ -54,7 +54,7 @@ public class TouchMode_RateableMovieViewHolderTest {
     @Test
     public void bindsOnSelectAction() {
         RateableMovieViewModel viewModel = viewModel(userActions).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(underTest()).perform(click());
 
@@ -64,7 +64,7 @@ public class TouchMode_RateableMovieViewHolderTest {
     @Test
     public void bindsOnToggleLikeAction() {
         RateableMovieViewModel viewModel = viewModel(userActions).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_image_like)).perform(click());
 
@@ -74,7 +74,7 @@ public class TouchMode_RateableMovieViewHolderTest {
     @Test
     public void bindsOnRateAction() {
         RateableMovieViewModel viewModel = viewModel(userActions).build();
-        rateableMovieViewHolder.bind(viewModel);
+        viewTestRule.runOnMainSynchronously(view -> rateableMovieViewHolder.bind(viewModel));
 
         onView(withId(R.id.item_rateable_rating)).perform(setRating(4.5f));
 

--- a/demo/src/androidTest/java/com/novoda/movies/rateable/TouchMode_RateableMovieViewHolderTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/rateable/TouchMode_RateableMovieViewHolderTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
-public class RateableMovieViewHolderTest {
+public class TouchMode_RateableMovieViewHolderTest {
 
     @Rule
     public ViewTestRule viewTestRule = new ViewTestRule(R.layout.item_view_rateable_movie);

--- a/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
+++ b/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
@@ -72,7 +72,6 @@ class RateableMovieViewHolder extends RecyclerView.ViewHolder {
 
     private void bindForIndirectAccess(Actions actions) {
         itemView.setOnClickListener(v -> new ActionsAlertDialogCreator(itemView.getContext()).create(actions).show());
-        likeImageView.setClickable(false);
         ratingBar.setOnRatingBarChangeListener(null);
         ratingBar.setIsIndicator(true);
     }

--- a/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
+++ b/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
@@ -52,7 +52,7 @@ class RateableMovieViewHolder extends RecyclerView.ViewHolder {
         ViewCompat.setAccessibilityDelegate(itemView, a11yDelegate);
         itemView.setContentDescription(viewModel.title + ", rating " + viewModel.rating + ", liked: " + viewModel.liked);
 
-        if (a11yServices.isSpokenFeedbackEnabled() || a11yServices.isSwitchAccessEnabled() || !itemView.isInTouchMode()) {
+        if (a11yServices.isSpokenFeedbackEnabled() || a11yServices.isSwitchAccessEnabled()) {
             bindForIndirectAccess(actions);
             a11yDelegate.setClickLabel(R.string.action_rateable_movie_usage_hint_click);
         } else {

--- a/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
+++ b/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
@@ -45,6 +45,7 @@ class RateableMovieViewHolder extends RecyclerView.ViewHolder {
         posterImageView.setImageResource(viewModel.poster);
         titleTextView.setText(viewModel.title);
         likeImageView.setImageResource(viewModel.liked ? R.drawable.ic_favorite_24dp : R.drawable.ic_favorite_border_24dp);
+        ratingBar.setOnRatingBarChangeListener(null);
         ratingBar.setRating(viewModel.rating);
         Actions actions = collateActionsFor(viewModel);
         ActionsAccessibilityDelegate a11yDelegate = new ActionsAccessibilityDelegate(itemView.getResources(), actions);
@@ -112,9 +113,7 @@ class RateableMovieViewHolder extends RecyclerView.ViewHolder {
         itemView.setOnClickListener(v -> viewModel.actions.onSelectMovie());
         likeImageView.setOnClickListener(v -> viewModel.actions.onToggleLike());
         ratingBar.setOnRatingBarChangeListener((ratingBar, rating, fromUser) -> {
-            if (fromUser) {
-                viewModel.actions.onRate(rating);
-            }
+            viewModel.actions.onRate(rating);
         });
     }
 }

--- a/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
+++ b/demo/src/main/java/com/novoda/movies/rateable/RateableMovieViewHolder.java
@@ -74,6 +74,7 @@ class RateableMovieViewHolder extends RecyclerView.ViewHolder {
         itemView.setOnClickListener(v -> new ActionsAlertDialogCreator(itemView.getContext()).create(actions).show());
         likeImageView.setClickable(false);
         ratingBar.setOnRatingBarChangeListener(null);
+        ratingBar.setIsIndicator(true);
     }
 
     private Action selectActionFor(RateableMovieViewModel viewModel) {
@@ -115,5 +116,6 @@ class RateableMovieViewHolder extends RecyclerView.ViewHolder {
         ratingBar.setOnRatingBarChangeListener((ratingBar, rating, fromUser) -> {
             viewModel.actions.onRate(rating);
         });
+        ratingBar.setIsIndicator(false);
     }
 }


### PR DESCRIPTION
## This PR

Adds tests to demonstrate usage of AccessibilityTestRule with SwitchAccess.

## Approach

These tests are a copy-paste of the TalkBack ones (which appears as a new file because of the rename 🙈).

This is because the behaviour in this app is identical whether switch/talkback is enabled.

There are some additional TalkBack tests I could add (verify usage hints are set) but these are included in the legacy tests so will move them over when they're deleted.