### PR TITLE
Add DirectViewCreator

### DIFF
--- a/core/src/main/java/com/novoda/espresso/DirectViewCreator.java
+++ b/core/src/main/java/com/novoda/espresso/DirectViewCreator.java
@@ -1,0 +1,24 @@
+package com.novoda.espresso;
+
+import android.content.Context;
+import android.support.annotation.LayoutRes;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+
+final class DirectViewCreator<T extends View> implements ViewCreator<T> {
+
+    private final T view;
+
+    DirectViewCreator(final T view) {
+        this.view = view;
+    }
+
+    @Override
+    public T createView(final Context ignored, final ViewGroup parent) {
+        view.setLayoutParams(new ViewGroup.LayoutParams(WRAP_CONTENT, WRAP_CONTENT));
+        return view;
+    }
+}

--- a/core/src/main/java/com/novoda/espresso/ViewTestRule.java
+++ b/core/src/main/java/com/novoda/espresso/ViewTestRule.java
@@ -25,6 +25,10 @@ public class ViewTestRule<T extends View> extends ActivityTestRule<EmptyActivity
         this(new InflateFromXmlViewCreator<T>(layoutId));
     }
 
+    public ViewTestRule(final T view) {
+        this(new DirectViewCreator<T>(view));
+    }
+
     public ViewTestRule(ViewCreator<T> viewCreator) {
         this(InstrumentationRegistry.getInstrumentation(), viewCreator);
     }

--- a/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
+++ b/demo/src/androidTest/java/com/novoda/movies/ProgrammaticallyCreatedViewTest.java
@@ -1,12 +1,11 @@
 package com.novoda.movies;
 
 import android.content.Context;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
-import android.view.ViewGroup;
 import android.widget.TextView;
 
-import com.novoda.espresso.ViewCreator;
 import com.novoda.espresso.ViewTestRule;
 
 import org.junit.Rule;
@@ -17,7 +16,6 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -26,22 +24,18 @@ public class ProgrammaticallyCreatedViewTest {
     private static final String TEXT = "Hello world!";
 
     @Rule
-    public ViewTestRule<TextView> viewTestRule = new ViewTestRule<>(new TextViewCreator());
+    public ViewTestRule<TextView> viewTestRule = new ViewTestRule<>(new TestTextView(
+            InstrumentationRegistry.getTargetContext()));
 
     @Test
     public void createdViewIsDisplayed() {
         onView(withText(TEXT)).check(matches(isDisplayed()));
     }
 
-    private static class TextViewCreator implements ViewCreator<TextView> {
-
-        @Override
-        public TextView createView(Context context, ViewGroup parentView) {
-            TextView textView = new TextView(context);
-            ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(WRAP_CONTENT, WRAP_CONTENT);
-            textView.setLayoutParams(layoutParams);
-            textView.setText(TEXT);
-            return textView;
+    private static class TestTextView extends TextView {
+        private TestTextView(final Context context) {
+            super(context);
+            setText(TEXT);
         }
     }
 }


### PR DESCRIPTION
Hello hello! I've tried to use this to test a custom view, but I've met a bit of an issue:

**The problem:** Right now, using `ViewTestRule` requires either an XML file or a new creator class that also sets the layout params of the view under test. This is just a mild annoyance as a quick glance at the code reveals what needs to be done by the developer using the library, but for convenience and in order to reduce margin for errors it could be interesting to have such a creator built into the library instead.
**The solution:** A new creator that takes already-built objects. It also sets the layout parameters to WRAP_CONTENT for both width and height, which I found a bit strange since the `README` specifies that that XML creator uses MATCH_PARENT instead and I thought having them be consistent was a reasonable assumption, but since `ProgrammaticallyCreatedViewTest` used WRAP_CONTENT I favored sticking to what's in the code.